### PR TITLE
Allow normal sys.excepthook behaviour

### DIFF
--- a/dreampielib/subprocess/__init__.py
+++ b/dreampielib/subprocess/__init__.py
@@ -70,6 +70,17 @@ import logging
 from logging import debug
 #logging.basicConfig(filename='/tmp/dreampie_subp_log', level=logging.DEBUG)
 
+def excepthook_nop(*args):
+    """
+    Replace python excepthook with this to avoid double traceback
+    printing. This way other modules which replace excepthook but still
+    call it will work correctly.
+    """
+    pass
+# Note that sys.excepthook might not be sys.__excepthook__ as e.g. on ubuntu
+# it's apport_excepthook we're replacing.
+sys.excepthook = excepthook_nop
+
 # time interval to process GUI events, in seconds
 GUI_SLEEP = 0.1
 


### PR DESCRIPTION
Without this change, the following snippet works correctly
in python but not in dreampie:

import sys
def f(*args): print 128371926419461
sys.excepthook = f
1/0
