### PR TITLE
Save Code Only

### DIFF
--- a/dreampielib/data/dreampie.glade
+++ b/dreampielib/data/dreampie.glade
@@ -1527,6 +1527,16 @@ You can also set the __expects_str__ attribute of a function to True to achieve 
         <signal name="activate" handler="on_copy_commands_only"/>
       </widget>
     </child>
+    <child>
+      <widget class="GtkMenuItem" id="save_commands_only_popmenu">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="label" translatable="yes">Save Code Only</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_save_commands_only"/>
+      </widget>
+    </child>
   </widget>
   <widget class="GtkWindow" id="window_main">
     <property name="can_focus">False</property>
@@ -1795,6 +1805,19 @@ You can also set the __expects_str__ attribute of a function to True to achieve 
                         <property name="label" translatable="yes">Copy Code Only</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="on_copy_commands_only"/>
+                        <accelerator key="c" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
+                      </widget>
+                    </child>
+                    <child>
+                      <widget class="GtkMenuItem" id="menuitem_save_commands_only">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="tooltip" translatable="yes">Save only the code, without output or leading dots.</property>
+                        <property name="use_action_appearance">False</property>
+                        <property name="label" translatable="yes">Save Code Only</property>
+                        <property name="use_underline">True</property>
+                        <signal name="activate" handler="on_save_commands_only"/>
                         <accelerator key="c" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                       </widget>
                     </child>

--- a/dreampielib/gui/__init__.py
+++ b/dreampielib/gui/__init__.py
@@ -333,6 +333,16 @@ class DreamPie(SimpleGladeApp):
     def on_copy_commands_only(self, _widget):
         return self.selection.copy_commands_only()
 
+    def on_save_commands_only(self, _widget):
+        """Prompts for a filename and saves only the selected commands
+        to the file"""
+        
+        def save_code(filename):
+            self.selection.save_commands_only(filename)
+
+        save_dialog(save_code, _("Choose where to save the code"),
+                    self.main_widget, _("Python Files"), "*.py", None)
+
     def on_paste(self, _widget):
         return self.selection.paste()
 
@@ -340,6 +350,7 @@ class DreamPie(SimpleGladeApp):
         self.menuitem_cut.props.sensitive = is_something_selected
         self.menuitem_copy.props.sensitive = is_something_selected
         self.menuitem_copy_commands_only.props.sensitive = is_something_selected
+        self.menuitem_save_commands_only.props.sensitive = is_something_selected
         self.menuitem_interrupt.props.sensitive = not is_something_selected
 
     # Source buffer, Text buffer

--- a/dreampielib/gui/selection.py
+++ b/dreampielib/gui/selection.py
@@ -84,7 +84,7 @@ class Selection(object):
         else:
             beep()
 
-    def copy_commands_only(self):
+    def commands_only(self):
         if self.sourcebuffer.get_has_selection():
             self.sourcebuffer.copy_clipboard(self.clipboard)
             return
@@ -109,10 +109,25 @@ class Selection(object):
                 r.append(get_text(tb, it, it2))
             it = it2
         r = ''.join(r)
+        return r
+    def copy_commands_only(self):
+        r = self.commands_only()
         if not r:
             beep()
         else:
             self.clipboard.set_text(r)
+
+    def save_commands_only(self, filename):
+        """Save only the selected commands to the specified filename;
+        if no commands are selected, beep and forget it"""
+
+        r = self.commands_only()
+        
+        if not r:
+            beep()
+        else:
+            with open(filename, "w") as f:
+                f.write(r)
 
     def paste(self):
         if self.sourceview.is_focus():


### PR DESCRIPTION
I added context-menu and menubar items to save code only to a file — I found that I want that functionality, and others may, too.  I kept it in the Edit menu, right beside Copy Code Only, for lack of a better place; but your taste may differ.
