### PR TITLE
autocompletion of unimported modules and files

### DIFF
--- a/dreampielib/subprocess/__init__.py
+++ b/dreampielib/subprocess/__init__.py
@@ -680,16 +680,20 @@ class Subprocess(object):
     
     @rpc_func
     def get_module_members(self, mod_name):
-        try:
-            mod = sys.modules[mod_name]
-        except KeyError:
-            return None
+        mod = sys.modules.get(mod_name)
+        subs = self.find_modules(mod_name)
+        
+        if mod is None:
+            return subs, []
+        
         if hasattr(mod, '__all__'):
             all_set = set(mod.__all__)
         else:
             all_set = None
         ids = [unicodify(x) for x in mod.__dict__.iterkeys()]
-        return self.split_list(ids, all_set)
+        ids.extend([x for x in submods if x not in ids])
+        
+        return self.split_list(sorted(ids), all_set)
     
     @rpc_func
     def complete_filenames(self, str_prefix, text, str_char, add_quote):

--- a/dreampielib/subprocess/__init__.py
+++ b/dreampielib/subprocess/__init__.py
@@ -219,6 +219,7 @@ class Subprocess(object):
         self.is_matplotlib_ia_switch = False
         self.is_matplotlib_ia_warn = False
         self.reshist_size = 0
+        self.parse_files_to_autocomplete = False
         
         # Did we already handle matplotlib in non-interactive mode?
         self.matplotlib_ia_handled = False
@@ -679,7 +680,10 @@ class Subprocess(object):
         return [unicodify(s) for s in find_modules(package)]
 
     def simple_parse_source(self, mod_name):
-        return [unicodify(x) for x in simple_parse_source(mod_name)]
+        if self.parse_files_to_autocomplete:
+            return [unicodify(x) for x in simple_parse_source(mod_name)]
+        else:
+            return []
 
     @rpc_func
     def get_module_members(self, mod_name):

--- a/dreampielib/subprocess/find_modules.py
+++ b/dreampielib/subprocess/find_modules.py
@@ -117,7 +117,7 @@ def find_modules(package):
     for name in sys.modules:
         if name.startswith(prefix):
             mod = name[len(prefix):]
-            if '.' not in mod:
+            if '.' not in mod and sys.modules[prefix+mod] is not None:
                 r.add(mod)
     r.discard('__init__')
     return sorted(r)


### PR DESCRIPTION
This is to improve autocompletion because currently there are cases where "from module.submodule" is able to autocomplete "submodule", but "from module import submodule" can't.

There are also cases where the autocomplete options for modules get overwritten if the \_\_init\_\_ at the level of that module has imports and has been executed. This behavior is updated to provide autocomplete options from the union of the submodules and \_\_init\_\_ contents.